### PR TITLE
Use last version of swi-prolog

### DIFF
--- a/prolog-swi-apt/Dockerfile
+++ b/prolog-swi-apt/Dockerfile
@@ -1,6 +1,7 @@
 FROM nacyot/ubuntu
 MAINTAINER Daekwon Kim <propellerheaven@gmail.com>
 
+RUN apt-add-repository ppa:swi-prolog/stable
 RUN apt-get update
 RUN apt-get install -y swi-prolog
 


### PR DESCRIPTION
Add official swi-prolog stable repository before installing swi-prolog so we get the last prolog version.
